### PR TITLE
FIX: purchase history automatized now, FIX: DTO for sales

### DIFF
--- a/src/main/java/com/example/demo/DTO/request/HistoryPurchaseRequestDTO.java
+++ b/src/main/java/com/example/demo/DTO/request/HistoryPurchaseRequestDTO.java
@@ -1,9 +1,0 @@
-package com.example.demo.DTO.request;
-
-import java.util.List;
-
-public record HistoryPurchaseRequestDTO(
-        Long provider,
-        List<String> itemPurchased
-) {
-}

--- a/src/main/java/com/example/demo/DTO/request/HistorySaleRequestDTO.java
+++ b/src/main/java/com/example/demo/DTO/request/HistorySaleRequestDTO.java
@@ -2,11 +2,10 @@ package com.example.demo.DTO.request;
 
 import com.example.demo.models.Pedido;
 
-import java.util.List;
 
 public record HistorySaleRequestDTO(
-        String nameofUser,
-        List<Long> cards,
+        Long userId,
+        Long card,
         Pedido pedido
 ) {
 }

--- a/src/main/java/com/example/demo/controller/HistoryPurchasedController.java
+++ b/src/main/java/com/example/demo/controller/HistoryPurchasedController.java
@@ -1,6 +1,5 @@
 package com.example.demo.controller;
 
-import com.example.demo.DTO.request.HistoryPurchaseRequestDTO;
 import com.example.demo.models.HistoryPurchased;
 import com.example.demo.service.HistoryPurchasedService;
 import lombok.AllArgsConstructor;
@@ -21,8 +20,8 @@ public class HistoryPurchasedController {
     List<HistoryPurchased> findAll() {return historyPurchasedService.getAllHistoryPurchases();}
 
     @PostMapping("/historypurchased/{id}")
-    public ResponseEntity<?> update(@PathVariable("id") Long id, @RequestBody HistoryPurchaseRequestDTO historyPurchaseDTO) {
-        return ResponseEntity.status(HttpStatus.OK).body(historyPurchasedService.update(id, historyPurchaseDTO));
+    public ResponseEntity<?> addHistoryPurchase(@PathVariable("id") Long id) {
+        return ResponseEntity.status(HttpStatus.OK).body(historyPurchasedService.addHistoryPurchase(id));
     }
 
     @DeleteMapping("/historypurchased/{id}")

--- a/src/main/java/com/example/demo/controller/HistorySaleController.java
+++ b/src/main/java/com/example/demo/controller/HistorySaleController.java
@@ -20,9 +20,9 @@ public class HistorySaleController {
     @GetMapping("/historySale/findAll")
     List<HistorySale> findAll() {return historySaleService.getAllHistorySales();}
 
-    @PostMapping("/historySale/{id}")
-    public ResponseEntity<?> update(@PathVariable("id") Long id, @RequestBody HistorySaleRequestDTO historySaleDTO) {
-        return ResponseEntity.status(HttpStatus.OK).body(historySaleService.update(id, historySaleDTO));
+    @PostMapping("/historySale/addSale")
+    public ResponseEntity<?> addHistorySale(@RequestBody HistorySaleRequestDTO historySaleDTO) {
+        return ResponseEntity.status(HttpStatus.OK).body(historySaleService.addHistorySale(historySaleDTO));
     }
 
     @DeleteMapping("/historySale/{id}")

--- a/src/main/java/com/example/demo/models/HistoryPurchased.java
+++ b/src/main/java/com/example/demo/models/HistoryPurchased.java
@@ -6,6 +6,8 @@ import lombok.*;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.example.demo.models.enums.ArticleCategory;
+
 @Entity
 @Setter
 @Getter
@@ -17,10 +19,9 @@ public class HistoryPurchased {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private Long provider;
     private LocalDate purchaseDate;
     @ElementCollection
-    private List<String> itemsPurchased;
+    private List<ArticleCategory> product;
 
 }

--- a/src/main/java/com/example/demo/models/HistorySale.java
+++ b/src/main/java/com/example/demo/models/HistorySale.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Entity
 @Setter
@@ -17,9 +16,8 @@ public class HistorySale {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String nameofUser;
-    @ElementCollection
-    private List<Long> cards;
+    private Long userId;
+    private Long card;
     private LocalDate dateSale;
 
     @OneToOne

--- a/src/main/java/com/example/demo/service/HistoryPurchasedService.java
+++ b/src/main/java/com/example/demo/service/HistoryPurchasedService.java
@@ -1,8 +1,10 @@
 package com.example.demo.service;
 
-import com.example.demo.DTO.request.HistoryPurchaseRequestDTO;
 import com.example.demo.models.HistoryPurchased;
+import com.example.demo.models.Providers;
 import com.example.demo.repository.HistoryPurchasedRepository;
+import com.example.demo.repository.ProvidersRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -12,31 +14,23 @@ import java.util.Optional;
 
 @Service
 public class HistoryPurchasedService {
-
     @Autowired
     private HistoryPurchasedRepository historyPurchasedRepository;
+    @Autowired
+    private ProvidersRepository providersRepository;
 
     public List<HistoryPurchased> getAllHistoryPurchases() {return historyPurchasedRepository.findAll();}
 
-    public String addHistoryPurchase(HistoryPurchaseRequestDTO historyPurchaseDTO) {
-
+    public String addHistoryPurchase(Long providerId) {
+        Optional<Providers> entityOptional = providersRepository.findById(providerId);
+        Providers provider = entityOptional.get();
         HistoryPurchased historyPurchased = HistoryPurchased.builder()
-                .provider(historyPurchaseDTO.provider())
+                .provider(providerId)
                 .purchaseDate(LocalDate.now())
-                .itemsPurchased(historyPurchaseDTO.itemPurchased())
+                .product(provider.getProduct())
                 .build();
         historyPurchasedRepository.save(historyPurchased);
         return "History purchase added";
-    }
-
-    public HistoryPurchased update(Long id, HistoryPurchaseRequestDTO entity) {
-
-        Optional<HistoryPurchased> entityOptional = historyPurchasedRepository.findById(id);
-        HistoryPurchased historyPurchased = entityOptional.get();
-        historyPurchased.setProvider(entity.provider());
-        historyPurchased.setPurchaseDate(LocalDate.now());
-        historyPurchased.setItemsPurchased(entity.itemPurchased());
-        return historyPurchasedRepository.save(historyPurchased);
     }
 
     public boolean delete(Long id) {

--- a/src/main/java/com/example/demo/service/HistorySaleService.java
+++ b/src/main/java/com/example/demo/service/HistorySaleService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class HistorySaleService {
@@ -20,23 +19,13 @@ public class HistorySaleService {
 
     public String addHistorySale(HistorySaleRequestDTO historySaleDTO) {
         HistorySale historySale = HistorySale.builder()
-                .nameofUser(historySaleDTO.nameofUser())
-                .cards(historySaleDTO.cards())
+                .userId(historySaleDTO.userId())
+                .card(historySaleDTO.card())
                 .dateSale(LocalDate.now())
                 .pedido(historySaleDTO.pedido())
                 .build();
         historySaleRepository.save(historySale);
         return "History Sale added";
-    }
-
-    public HistorySale update(Long id, HistorySaleRequestDTO entity) {
-        Optional<HistorySale> entityOptional = historySaleRepository.findById(id);
-        HistorySale historySale = entityOptional.get();
-        historySale.setNameofUser(entity.nameofUser());
-        historySale.setCards(entity.cards());
-        historySale.setDateSale(LocalDate.now());
-        historySale.setPedido(entity.pedido());
-        return historySaleRepository.save(historySale);
     }
 
     public boolean delete(Long id) {

--- a/src/main/java/com/example/demo/service/ProvidersService.java
+++ b/src/main/java/com/example/demo/service/ProvidersService.java
@@ -18,6 +18,8 @@ public class ProvidersService {
     private ProvidersRepository providersRepository;
     @Autowired
     private ArticleRepository articleRepository;
+    @Autowired
+    private HistoryPurchasedService historyPurchasedService;
 
     public List<Providers> getAllProviders() {
         return providersRepository.findAll();
@@ -49,6 +51,7 @@ public class ProvidersService {
             articleJpa.setLastPurchased(currentDate);
             articleRepository.save(articleJpa);
         }
+        historyPurchasedService.addHistoryPurchase(id);
         return "Articles Purchased";
     }
 


### PR DESCRIPTION
arregle los pedos del ulises de nuevo.

Borre el DTO de compra porque no tiene sentido pasar una lista de productos cuando eso puede ser automatizado por el backend. Ahora el endpoint toma un ID y el service hace el resto.

Cambie el DTO de venta, por la inconsistencia de pasar un nombre de registro en lugar del ID.

Arregle los controllers de ambos historiales porque no habia endpoint para agregar un nuevo registro, solo se podia acutalizar uno ya existente. Lo cual es imposible porque no se podia crear uno en primer lugar. Ademas borre la funcion de actualizar registrios, actualiar un registro de venta solo puede dar lugar a mal entendidos y errores.

